### PR TITLE
Use v1.3.0 contracts

### DIFF
--- a/safe_cli/safe_addresses.py
+++ b/safe_cli/safe_addresses.py
@@ -1,11 +1,6 @@
-# https://github.com/gnosis/safe-deployments/tree/main/src/assets/v1.2.0
-LAST_SAFE_CONTRACT = '0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F'
+# https://github.com/gnosis/safe-deployments/tree/main/src/assets/v1.3.0
+LAST_SAFE_CONTRACT = '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552'
 LAST_DEFAULT_CALLBACK_HANDLER = '0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4'
 LAST_PROXY_FACTORY_CONTRACT = '0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2'
 LAST_MULTISEND_CONTRACT = '0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761'
 LAST_MULTISEND_CALL_ONLY_CONTRACT = '0x40A2aCCbd92BCA938b02010E17A5b8929b49130D'
-
-# https://github.com/gnosis/safe-deployments/tree/main/src/assets/v1.3.0
-# Don't use v1.3.0 contracts yet, as they are not supported in the web interface/mobile apps
-# If you want to use them just uncomment the following line
-# LAST_SAFE_CONTRACT = '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552'


### PR DESCRIPTION
Replaces `LAST_SAFE_CONTRACT` with version `1.3.0`